### PR TITLE
Add missing omniauth-oauth2 depenedency

### DIFF
--- a/omniauth-smartsheet.gemspec
+++ b/omniauth-smartsheet.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'omniauth', '~> 1.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.1'
 end


### PR DESCRIPTION
Currently raises an error if you don't specifically include the omniauth-oauth2 gem in your Gemfile.
